### PR TITLE
switched placement of root svg element

### DIFF
--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -48,7 +48,7 @@
             info.svg.style.top = 0;
             info.svg.style.width = '100%';
             info.svg.style.height = '100%';
-            this.container.insertBefore(info.svg, this.canvas.nextSibling);
+            this.canvas.appendChild(info.svg);
 
             info.node = document.createElementNS(svgNS, 'g');
             info.svg.appendChild(info.node);


### PR DESCRIPTION
Now you can spread on svg elements and still zoom seadragon.
