### PR TITLE
feat: add rotation support

### DIFF
--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -46,6 +46,10 @@
             self.resize();
         });
 
+        this._viewer.addHandler('rotate', function(evt) {
+            self.resize();
+        });
+
         this.resize();
     };
 
@@ -70,10 +74,11 @@
 
             var p = this._viewer.viewport.pixelFromPoint(new OpenSeadragon.Point(0, 0), true);
             var zoom = this._viewer.viewport.getZoom(true);
+            var rotation = this._viewer.viewport.getRotation();
             // TODO: Expose an accessor for _containerInnerSize in the OSD API so we don't have to use the private variable.
             var scale = this._viewer.viewport._containerInnerSize.x * zoom;
             this._node.setAttribute('transform',
-                'translate(' + p.x + ',' + p.y + ') scale(' + scale + ')');
+                'translate(' + p.x + ',' + p.y + ') scale(' + scale + ') rotate(' + rotation + ')');
         },
 
         // ----------


### PR DESCRIPTION
OpenSeadragon overlay supports rotation since https://github.com/openseadragon/openseadragon/pull/896
Apply rotation to SVG overlay

Requires latest build of OpenSeadragon (or 2.2 after it released)
