### PR TITLE
Resize overlay on viewer.resize (fix #18)

### DIFF
--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -50,6 +50,10 @@
             self.resize();
         });
 
+        this._viewer.addHandler('resize', function() {
+            self.resize();
+        });
+
         this.resize();
     };
 


### PR DESCRIPTION
Might need verification as to when (which version of OSD) the viewer.resize event was implemented.