### PR TITLE
require openseadragon if it doesn't exist

### DIFF
--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -2,15 +2,19 @@
 
 (function() {
 
-    if (!window.OpenSeadragon) {
-        console.error('[openseadragon-svg-overlay] requires OpenSeadragon');
-        return;
+    $ = window.OpenSeadragon;
+    
+    if (!$) {
+    $ = require('openseadragon');
+        if (!$) {
+            throw new Error('OpenSeadragon is missing.');
+        }
     }
 
     var svgNS = 'http://www.w3.org/2000/svg';
 
     // ----------
-    OpenSeadragon.Viewer.prototype.svgOverlay = function() {
+    $.Viewer.prototype.svgOverlay = function() {
         if (this._svgOverlayInfo) {
             return this._svgOverlayInfo;
         }
@@ -76,7 +80,7 @@
                 this._svg.setAttribute('height', this._containerHeight);
             }
 
-            var p = this._viewer.viewport.pixelFromPoint(new OpenSeadragon.Point(0, 0), true);
+            var p = this._viewer.viewport.pixelFromPoint(new $.Point(0, 0), true);
             var zoom = this._viewer.viewport.getZoom(true);
             var rotation = this._viewer.viewport.getRotation();
             // TODO: Expose an accessor for _containerInnerSize in the OSD API so we don't have to use the private variable.
@@ -89,7 +93,7 @@
         onClick: function(node, handler) {
             // TODO: Fast click for mobile browsers
 
-            new OpenSeadragon.MouseTracker({
+            new $.MouseTracker({
                 element: node,
                 clickHandler: handler
             }).setTracking(true);

--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -5,7 +5,7 @@
     $ = window.OpenSeadragon;
     
     if (!$) {
-    $ = require('openseadragon');
+        $ = require('openseadragon');
         if (!$) {
             throw new Error('OpenSeadragon is missing.');
         }


### PR DESCRIPTION
Fixes the `[openseadragon-svg-overlay] requires OpenSeadragon` error when doing this:

```
import OpenSeadragon from 'openseadragon';
import 'svg-overlay';
```

Borrowed style from https://github.com/usnistgov/OpenSeadragonFiltering/blob/master/openseadragon-filtering.js

setting OpenSeadragon object to `$`