### PR TITLE
Upgrade d3 and remove charset attribute in demo

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -5,7 +5,7 @@
         <script src="https://cdn.jsdelivr.net/npm/openseadragon@2.3/build/openseadragon/openseadragon.min.js"></script>
         <script src="openseadragon-svg-overlay.js"></script>
         <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
-        <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
+        <script src="//d3js.org/d3.v5.min.js"></script>
         <style type="text/css">
 
             html,


### PR DESCRIPTION
Hello, this patch removes obsolete charset in the script tag for d3.js and upgrades it to latest v5 which also works fine with this plugin.