### PR TITLE
.svg Flip

### DIFF
--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -89,21 +89,19 @@
             var rotation = this._viewer.viewport.getRotation();
             var flipped = this._viewer.viewport.getFlip();
             // TODO: Expose an accessor for _containerInnerSize in the OSD API so we don't have to use the private variable.
-            var scale = this._viewer.viewport._containerInnerSize.x * zoom;
+            var scaleX = this._viewer.viewport._containerInnerSize.x * zoom;
+            var scaleY = this._viewer.viewport._containerInnerSize.x * zoom;
             
             if(flipped){
+                // Makes the x component of the scale negative to flip the svg
+                scaleX = -scaleX;
                 // Translates svg back into the correct coordinates when the x scale is made negative.
                 p.x = -p.x + this._viewer.viewport._containerInnerSize.x;
-                // Makes the x component of the scale negative to flip the svg
-                this._node.setAttribute('transform',
-                    'translate(' + p.x + ',' + p.y + ') scale(' + -scale + ',' + scale + ') rotate(' + rotation + ')');
-            } else {
-                this._node.setAttribute('transform',
-                    'translate(' + p.x + ',' + p.y + ') scale(' + scale + ') rotate(' + rotation + ')');
             }
 
+            this._node.setAttribute('transform',
+                'translate(' + p.x + ',' + p.y + ') scale(' + scaleX + ',' + scaleY + ') rotate(' + rotation + ')');
         },
-
         // ----------
         onClick: function(node, handler) {
             // TODO: Fast click for mobile browsers

--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -89,14 +89,15 @@
             var rotation = this._viewer.viewport.getRotation();
             var flipped = this._viewer.viewport.getFlip();
             // TODO: Expose an accessor for _containerInnerSize in the OSD API so we don't have to use the private variable.
-            var scaleX = this._viewer.viewport._containerInnerSize.x * zoom;
-            var scaleY = this._viewer.viewport._containerInnerSize.x * zoom;
+            var containerSizeX = this._viewer.viewport._containerInnerSize.x
+            var scaleX = containerSizeX * zoom;
+            var scaleY = scaleX;
             
             if(flipped){
                 // Makes the x component of the scale negative to flip the svg
                 scaleX = -scaleX;
                 // Translates svg back into the correct coordinates when the x scale is made negative.
-                p.x = -p.x + this._viewer.viewport._containerInnerSize.x;
+                p.x = -p.x + containerSizeX;
             }
 
             this._node.setAttribute('transform',

--- a/openseadragon-svg-overlay.js
+++ b/openseadragon-svg-overlay.js
@@ -54,6 +54,10 @@
             self.resize();
         });
 
+        this._viewer.addHandler('flip', function() {
+          self.resize();
+        });
+
         this._viewer.addHandler('resize', function() {
             self.resize();
         });
@@ -83,10 +87,21 @@
             var p = this._viewer.viewport.pixelFromPoint(new $.Point(0, 0), true);
             var zoom = this._viewer.viewport.getZoom(true);
             var rotation = this._viewer.viewport.getRotation();
+            var flipped = this._viewer.viewport.getFlip();
             // TODO: Expose an accessor for _containerInnerSize in the OSD API so we don't have to use the private variable.
             var scale = this._viewer.viewport._containerInnerSize.x * zoom;
-            this._node.setAttribute('transform',
-                'translate(' + p.x + ',' + p.y + ') scale(' + scale + ') rotate(' + rotation + ')');
+            
+            if(flipped){
+                // Translates svg back into the correct coordinates when the x scale is made negative.
+                p.x = -p.x + this._viewer.viewport._containerInnerSize.x;
+                // Makes the x component of the scale negative to flip the svg
+                this._node.setAttribute('transform',
+                    'translate(' + p.x + ',' + p.y + ') scale(' + -scale + ',' + scale + ') rotate(' + rotation + ')');
+            } else {
+                this._node.setAttribute('transform',
+                    'translate(' + p.x + ',' + p.y + ') scale(' + scale + ') rotate(' + rotation + ')');
+            }
+
         },
 
         // ----------


### PR DESCRIPTION
This pull request is for adding "Flip" functionality to svg overlays.  It flips (mirrors) the svg on top of the tiled image when the tiled image is flipped.  The flipped state of the tiled image and the svg are tied together, much as they are with rotation.